### PR TITLE
Upgrade all dependencies (2026-07 edition).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,50 +10,51 @@ repository = "https://github.com/drogue-iot/embedded-tls"
 license = "Apache-2.0"
 keywords = ["embedded", "async", "tls", "no_std", "network"]
 exclude = [".github"]
+rust-version = "1.87"
 
 [package.metadata.docs.rs]
 features = ["webpki", "rustpki", "rsa", "ed25519", "p384"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-portable-atomic = { version = "1.6.0", default-features = false }
-p256 = { version = "0.13", default-features = false, features = [ "ecdh", "ecdsa", "sha256" ] }
-p384 = { version = "0.13", default-features = false, features = [ "ecdsa", "sha384" ], optional = true }
-ed25519-dalek = { version = "2.2", default-features = false, optional = true }
-rsa = { version = "0.9.9", default-features = false, features = ["sha2"], optional = true }
-rand_core = { version = "0.6.3", default-features = false }
-hkdf = "0.12.3"
-hmac = "0.12.1"
-sha2 = { version = "0.10.2", default-features = false }
-aes-gcm = { version = "0.10.1", default-features = false, features = ["aes"] }
-digest = { version = "0.10.3", default-features = false, features = [ "core-api" ] }
-typenum = { version = "1.15.0", default-features = false }
-heapless = { version = "0.9", default-features = false }
-embedded-io = "0.7"
-embedded-io-async = "0.7"
-embedded-io-adapters = { version = "0.7", optional = true }
-generic-array = { version = "0.14", default-features = false }
-webpki = { package = "rustls-webpki", version = "0.101.7", default-features = false, optional = true }
-const-oid = { version = "0.10.1", optional = true }
-der = { version = "0.8.0-rc.2", features = ["derive", "oid", "time", "heapless"], optional = true }
-signature = { version = "2.2", default-features = false }
-ecdsa = { version = "0.16.9", default-features = false }
+portable-atomic = { version = "1.13.1", default-features = false }
+p256 = { version = "0.14.0", default-features = false, features = ["ecdh", "ecdsa", "pkcs8", "sha256"] }
+p384 = { version = "0.14.0", default-features = false, features = ["ecdsa", "sha384"], optional = true }
+ed25519-dalek = { version = "3.0.0", default-features = false, optional = true }
+rsa = { version = "0.10.0-rc.18", default-features = false, features = ["encoding", "sha2"], optional = true }
+rand_core = { version = "0.10.1", default-features = false }
+hkdf = "0.13.0"
+hmac = "0.13.0"
+sha2 = { version = "0.11.0", default-features = false }
+aes-gcm = { version = "0.11.0", default-features = false, features = ["aes"] }
+digest = "0.11.3"
+heapless = { version = "0.9.3", default-features = false }
+embedded-io = "0.7.1"
+embedded-io-async = "0.7.0"
+embedded-io-adapters = { version = "0.7.0", optional = true }
+pki-types = { package = "rustls-pki-types", version = "1.15.0", default-features = false, optional = true }
+webpki = { package = "rustls-webpki", version = "0.103.13", default-features = false, optional = true }
+const-oid = { version = "0.10.2", optional = true }
+der = { version = "0.8.1", features = ["derive", "oid", "time"], optional = true }
+signature = { version = "3.0.0", default-features = false }
+ecdsa = { version = "0.17.0", default-features = false }
 
 # Logging alternatives
 log = { version = "0.4", optional = true }
-defmt = { version = "1.0.1", optional = true }
+defmt = { version = "1.1.1", optional = true }
 
 [dev-dependencies]
 env_logger = "0.11"
 tokio = { version = "1", features = ["full"] }
-mio = { version = "0.8.3", features = ["os-poll", "net"] }
-rustls = "0.21.6"
-rustls-pemfile = "1.0"
+mio = { version = "1.2.2", features = ["os-poll", "net"] }
+# We deliberately disable default features to not pull in TLS 1.2 support.
+rustls = { version = "0.23.42", features = ["ring", "std"], default-features = false }
+rustls-pemfile = "2.2.0"
 serde = { version = "1.0", features = ["derive"] }
-rand = "0.8"
+rand = "0.10.2"
 log = "0.4"
 pem-parser = "0.1.1"
-openssl = "0.10.44"
+openssl = "0.10.81"
 
 [features]
 default = ["std", "log", "tokio"]
@@ -61,7 +62,7 @@ defmt = ["dep:defmt", "embedded-io/defmt", "heapless/defmt"]
 std = ["embedded-io/std", "embedded-io-async/std"]
 tokio = ["embedded-io-adapters/tokio-1"]
 alloc = []
-webpki = ["dep:webpki"]
+webpki = ["dep:pki-types", "dep:webpki"]
 rustpki = ["dep:der","dep:const-oid"]
 rsa = ["dep:rsa", "rustpki", "alloc"]
 ed25519 = ["dep:ed25519-dalek", "rustpki"]

--- a/examples/blocking/Cargo.toml
+++ b/examples/blocking/Cargo.toml
@@ -13,5 +13,5 @@ embedded-io = { version = "0.7.0" }
 embedded-io-adapters = { version = "0.7.0", features = ["std"] }
 pem-parser = "0.1"
 env_logger = "0.10"
-rand = "0.8"
+rand = "0.10.2"
 log = "0.4"

--- a/examples/blocking/src/main.rs
+++ b/examples/blocking/src/main.rs
@@ -1,22 +1,22 @@
+use std::net::TcpStream;
+use std::time::SystemTime;
+
 use embedded_io::Write as _;
 use embedded_io_adapters::std::FromStd;
 use embedded_tls::blocking::*;
 use embedded_tls::webpki::CertVerifier;
-use rand::rngs::OsRng;
-use std::net::TcpStream;
-use std::time::SystemTime;
 
-struct Provider<'a> {
-    rng: OsRng,
+struct Provider<'a, RNG> {
+    rng: RNG,
     verifier: CertVerifier<'a, Aes128GcmSha256, SystemTime, 4096>,
 }
 
-impl CryptoProvider for Provider<'_> {
+impl<RNG: CryptoRng> CryptoProvider for Provider<'_, RNG> {
     type CipherSuite = Aes128GcmSha256;
 
     type Signature = &'static [u8];
 
-    fn rng(&mut self) -> impl embedded_tls::CryptoRngCore {
+    fn rng(&mut self) -> impl embedded_tls::CryptoRng {
         &mut self.rng
     }
 
@@ -57,7 +57,7 @@ fn main() {
     tls.open(TlsContext::new(
         &config,
         Provider {
-            rng: OsRng,
+            rng: rand::rng(),
             verifier: CertVerifier::new(Certificate::X509(&der)),
         },
     ))

--- a/examples/embassy/Cargo.toml
+++ b/examples/embassy/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 [dependencies]
 embedded-tls = { path = "../..", features = ["alloc", "std", "log"], default-features = false }
 env_logger = "0.10"
-rand = "0.8"
+rand = "0.10.2"
 log = "0.4"
 static_cell = "1"
 embassy-executor = { version = "0.9", features = ["arch-std", "executor-thread", "log"] }

--- a/examples/embassy/src/main.rs
+++ b/examples/embassy/src/main.rs
@@ -8,7 +8,7 @@ use embedded_io_async::Write;
 use embedded_tls::{Aes128GcmSha256, TlsConfig, TlsConnection, TlsContext, UnsecureProvider};
 use heapless::Vec;
 use log::*;
-use rand::{rngs::OsRng, RngCore};
+use rand::RngCore;
 use static_cell::StaticCell;
 
 #[derive(Parser)]
@@ -47,7 +47,7 @@ async fn main_task(spawner: Spawner) {
 
     // Generate random seed
     let mut seed = [0; 8];
-    OsRng.fill_bytes(&mut seed);
+    rand::rng().fill_bytes(&mut seed);
     let seed = u64::from_le_bytes(seed);
 
     // Init network stack
@@ -81,7 +81,7 @@ async fn main_task(spawner: Spawner) {
 
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .await
     .expect("error establishing TLS connection");

--- a/examples/tokio-psk/Cargo.toml
+++ b/examples/tokio-psk/Cargo.toml
@@ -9,6 +9,6 @@ embedded-io-adapters = { version = "0.7", features = ["tokio-1"] }
 embedded-io-async = "0.7"
 env_logger = "0.10"
 tokio = { version = "1", features = ["full"] }
-rand = "0.8"
+rand = "0.10.2"
 log = "0.4"
 pem-parser = "0.1.1"

--- a/examples/tokio-psk/src/main.rs
+++ b/examples/tokio-psk/src/main.rs
@@ -1,10 +1,10 @@
 #![macro_use]
 
+use std::error::Error;
+
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_io_async::Write as _;
 use embedded_tls::*;
-use rand::rngs::OsRng;
-use std::error::Error;
 use tokio::net::TcpStream;
 
 #[tokio::main]
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .await
     .expect("error establishing TLS connection");

--- a/examples/tokio/Cargo.toml
+++ b/examples/tokio/Cargo.toml
@@ -13,6 +13,6 @@ embedded-io-adapters = { version = "0.7", features = ["tokio-1"] }
 embedded-io-async = "0.7"
 env_logger = "0.10"
 tokio = { version = "1", features = ["full"] }
-rand = "0.8"
+rand = "0.10.2"
 log = "0.4"
 pem-parser = "0.1.1"

--- a/examples/tokio/src/main.rs
+++ b/examples/tokio/src/main.rs
@@ -1,10 +1,10 @@
 #![macro_use]
 
+use std::error::Error;
+
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_io_async::Write as _;
 use embedded_tls::*;
-use rand::rngs::OsRng;
-use std::error::Error;
 use tokio::net::TcpStream;
 
 #[tokio::main]
@@ -25,7 +25,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .await
     .expect("error establishing TLS connection");

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "stable"
+channel = "1.87"
 components = [ "rustfmt", "clippy" ]
 targets = [ "thumbv7em-none-eabi" ]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,23 +1,24 @@
 use core::marker::PhantomData;
 
+use aes_gcm::{AeadInOut, Aes128Gcm, Aes256Gcm, KeyInit};
+use digest::array::ArraySize;
+use digest::block_api::BlockSizeUser;
+use digest::typenum::{Sum, U10, U12, U16, U32};
+use digest::{Digest, FixedOutput, OutputSizeUser, Reset};
+use ecdsa::elliptic_curve::SecretKey;
+use heapless::Vec;
+use p256::ecdsa::SigningKey;
+use rand_core::CryptoRng;
+pub use sha2::Sha256;
+pub use sha2::Sha384;
+
 use crate::TlsError;
 use crate::cipher_suites::CipherSuite;
+pub use crate::extensions::extension_data::max_fragment_length::MaxFragmentLength;
 use crate::extensions::extension_data::signature_algorithms::SignatureScheme;
 use crate::extensions::extension_data::supported_groups::NamedGroup;
 pub use crate::handshake::certificate::{CertificateEntryRef, CertificateRef};
 pub use crate::handshake::certificate_verify::CertificateVerifyRef;
-use aes_gcm::{AeadInPlace, Aes128Gcm, Aes256Gcm, KeyInit};
-use digest::core_api::BlockSizeUser;
-use digest::{Digest, FixedOutput, OutputSizeUser, Reset};
-use ecdsa::elliptic_curve::SecretKey;
-use generic_array::ArrayLength;
-use heapless::Vec;
-use p256::ecdsa::SigningKey;
-use rand_core::CryptoRngCore;
-pub use sha2::{Sha256, Sha384};
-use typenum::{Sum, U10, U12, U16, U32};
-
-pub use crate::extensions::extension_data::max_fragment_length::MaxFragmentLength;
 
 pub const TLS_RECORD_OVERHEAD: usize = 128;
 
@@ -32,12 +33,12 @@ type LabelBuffer<CipherSuite> = Sum<
 /// Represents a TLS 1.3 cipher suite
 pub trait TlsCipherSuite {
     const CODE_POINT: u16;
-    type Cipher: KeyInit<KeySize = Self::KeyLen> + AeadInPlace<NonceSize = Self::IvLen>;
-    type KeyLen: ArrayLength<u8>;
-    type IvLen: ArrayLength<u8>;
+    type Cipher: KeyInit<KeySize = Self::KeyLen> + AeadInOut<NonceSize = Self::IvLen>;
+    type KeyLen: ArraySize;
+    type IvLen: ArraySize;
 
     type Hash: Digest + Reset + Clone + OutputSizeUser + BlockSizeUser + FixedOutput;
-    type LabelBufferSize: ArrayLength<u8>;
+    type LabelBufferSize: ArraySize;
 }
 
 pub struct Aes128GcmSha256;
@@ -142,7 +143,7 @@ pub trait CryptoProvider {
     type CipherSuite: TlsCipherSuite;
     type Signature: AsRef<[u8]>;
 
-    fn rng(&mut self) -> impl CryptoRngCore;
+    fn rng(&mut self) -> impl CryptoRng;
 
     fn verifier(&mut self) -> Result<&mut impl TlsVerifier<Self::CipherSuite>, crate::TlsError> {
         Err::<&mut NoVerify, _>(crate::TlsError::Unimplemented)
@@ -154,8 +155,7 @@ pub trait CryptoProvider {
     /// crypto module such as an HSM/TPM/secure element).
     fn signer(
         &mut self,
-    ) -> Result<(impl signature::SignerMut<Self::Signature>, SignatureScheme), crate::TlsError>
-    {
+    ) -> Result<(impl signature::Signer<Self::Signature>, SignatureScheme), crate::TlsError> {
         Err::<(NoSign, _), crate::TlsError>(crate::TlsError::Unimplemented)
     }
 
@@ -175,7 +175,7 @@ impl<T: CryptoProvider> CryptoProvider for &mut T {
 
     type Signature = T::Signature;
 
-    fn rng(&mut self) -> impl CryptoRngCore {
+    fn rng(&mut self) -> impl CryptoRng {
         T::rng(self)
     }
 
@@ -185,8 +185,7 @@ impl<T: CryptoProvider> CryptoProvider for &mut T {
 
     fn signer(
         &mut self,
-    ) -> Result<(impl signature::SignerMut<Self::Signature>, SignatureScheme), crate::TlsError>
-    {
+    ) -> Result<(impl signature::Signer<Self::Signature>, SignatureScheme), crate::TlsError> {
         T::signer(self)
     }
 
@@ -210,7 +209,7 @@ pub struct UnsecureProvider<'a, CipherSuite, RNG> {
     _marker: PhantomData<CipherSuite>,
 }
 
-impl<RNG: CryptoRngCore> UnsecureProvider<'_, (), RNG> {
+impl<RNG: CryptoRng> UnsecureProvider<'_, (), RNG> {
     pub fn new<CipherSuite: TlsCipherSuite>(
         rng: RNG,
     ) -> UnsecureProvider<'static, CipherSuite, RNG> {
@@ -223,7 +222,7 @@ impl<RNG: CryptoRngCore> UnsecureProvider<'_, (), RNG> {
     }
 }
 
-impl<'a, CipherSuite: TlsCipherSuite, RNG: CryptoRngCore> UnsecureProvider<'a, CipherSuite, RNG> {
+impl<'a, CipherSuite: TlsCipherSuite, RNG: CryptoRng> UnsecureProvider<'a, CipherSuite, RNG> {
     pub fn with_priv_key(mut self, priv_key: &'a [u8]) -> Self {
         self.priv_key = Some(priv_key);
         self
@@ -235,20 +234,19 @@ impl<'a, CipherSuite: TlsCipherSuite, RNG: CryptoRngCore> UnsecureProvider<'a, C
     }
 }
 
-impl<CipherSuite: TlsCipherSuite, RNG: CryptoRngCore> CryptoProvider
+impl<CipherSuite: TlsCipherSuite, RNG: CryptoRng> CryptoProvider
     for UnsecureProvider<'_, CipherSuite, RNG>
 {
     type CipherSuite = CipherSuite;
     type Signature = p256::ecdsa::DerSignature;
 
-    fn rng(&mut self) -> impl CryptoRngCore {
+    fn rng(&mut self) -> impl CryptoRng {
         &mut self.rng
     }
 
     fn signer(
         &mut self,
-    ) -> Result<(impl signature::SignerMut<Self::Signature>, SignatureScheme), crate::TlsError>
-    {
+    ) -> Result<(impl signature::Signer<Self::Signature>, SignatureScheme), crate::TlsError> {
         let key_der = self.priv_key.ok_or(TlsError::InvalidPrivateKey)?;
         let secret_key =
             SecretKey::from_sec1_der(key_der).map_err(|_| TlsError::InvalidPrivateKey)?;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,6 +1,21 @@
+use core::fmt::Debug;
+
+use aes_gcm::aead::{AeadCore, AeadInOut, KeyInit};
+use digest::Digest;
+use digest::typenum::Unsigned;
+use embedded_io::Error as _;
+use embedded_io::{Read as BlockingRead, Write as BlockingWrite};
+use embedded_io_async::{Read as AsyncRead, Write as AsyncWrite};
+use p256::ecdh::EphemeralSecret;
+use signature::Signer;
+
+use crate::application_data::ApplicationData;
+use crate::buffer::CryptoBuffer;
 use crate::config::{TlsCipherSuite, TlsConfig};
+use crate::content_types::ContentType;
 use crate::handshake::{ClientHandshake, ServerHandshake};
 use crate::key_schedule::{KeySchedule, ReadKeySchedule, WriteKeySchedule};
+use crate::parse_buffer::ParseBuffer;
 use crate::record::{ClientRecord, ServerRecord};
 use crate::record_reader::RecordReader;
 use crate::write_buffer::WriteBuffer;
@@ -9,21 +24,6 @@ use crate::{
     alert::{Alert, AlertDescription, AlertLevel},
     handshake::{certificate::CertificateRef, certificate_request::CertificateRequest},
 };
-use core::fmt::Debug;
-use digest::Digest;
-use embedded_io::Error as _;
-use embedded_io::{Read as BlockingRead, Write as BlockingWrite};
-use embedded_io_async::{Read as AsyncRead, Write as AsyncWrite};
-
-use crate::application_data::ApplicationData;
-use crate::buffer::CryptoBuffer;
-use digest::generic_array::typenum::Unsigned;
-use p256::ecdh::EphemeralSecret;
-use signature::SignerMut;
-
-use crate::content_types::ContentType;
-use crate::parse_buffer::ParseBuffer;
-use aes_gcm::aead::{AeadCore, AeadInPlace, KeyInit};
 
 pub(crate) fn decrypt_record<CipherSuite>(
     key_schedule: &mut ReadKeySchedule<CipherSuite>,
@@ -546,7 +546,7 @@ where
     Provider: CryptoProvider,
 {
     let (result, record) = match crypto_provider.signer() {
-        Ok((mut signing_key, signature_scheme)) => {
+        Ok((signing_key, signature_scheme)) => {
             let ctx_str = b"TLS 1.3, client CertificateVerify\x00";
 
             // 64 (pad) + 34 (ctx) + 48 (SHA-384) = 146 bytes required

--- a/src/handshake/binder.rs
+++ b/src/handshake/binder.rs
@@ -1,28 +1,28 @@
+use core::fmt::{Debug, Formatter};
+
+use digest::array::{Array, ArraySize};
+
 use crate::TlsError;
 use crate::buffer::CryptoBuffer;
-use core::fmt::{Debug, Formatter};
-//use digest::generic_array::{ArrayLength, GenericArray};
-use generic_array::{ArrayLength, GenericArray};
-// use heapless::Vec;
 
-pub struct PskBinder<N: ArrayLength<u8>> {
-    pub verify: GenericArray<u8, N>,
+pub struct PskBinder<N: ArraySize> {
+    pub verify: Array<u8, N>,
 }
 
 #[cfg(feature = "defmt")]
-impl<N: ArrayLength<u8>> defmt::Format for PskBinder<N> {
+impl<N: ArraySize> defmt::Format for PskBinder<N> {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f, "verify length:{}", &self.verify.len());
     }
 }
 
-impl<N: ArrayLength<u8>> Debug for PskBinder<N> {
+impl<N: ArraySize> Debug for PskBinder<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("PskBinder").finish()
     }
 }
 
-impl<N: ArrayLength<u8>> PskBinder<N> {
+impl<N: ArraySize> PskBinder<N> {
     pub(crate) fn encode(&self, buf: &mut CryptoBuffer<'_>) -> Result<(), TlsError> {
         let len = self.verify.len() as u8;
         //buf.extend_from_slice(&[len[1], len[2], len[3]]);

--- a/src/handshake/certificate.rs
+++ b/src/handshake/certificate.rs
@@ -1,8 +1,9 @@
+use heapless::Vec;
+
 use crate::TlsError;
 use crate::buffer::CryptoBuffer;
 use crate::extensions::messages::CertificateExtension;
 use crate::parse_buffer::ParseBuffer;
-use heapless::Vec;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/src/handshake/certificate_request.rs
+++ b/src/handshake/certificate_request.rs
@@ -1,7 +1,8 @@
+use heapless::Vec;
+
 use crate::extensions::messages::CertificateRequestExtension;
 use crate::parse_buffer::ParseBuffer;
 use crate::{TlsError, unused};
-use heapless::Vec;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/src/handshake/client_hello.rs
+++ b/src/handshake/client_hello.rs
@@ -1,11 +1,12 @@
 use core::marker::PhantomData;
 
+use digest::typenum::Unsigned;
 use digest::{Digest, OutputSizeUser};
 use heapless::Vec;
-use p256::EncodedPoint;
+use p256::Sec1Point;
 use p256::ecdh::EphemeralSecret;
-use p256::elliptic_curve::rand_core::RngCore;
-use typenum::Unsigned;
+use p256::elliptic_curve::Generate;
+use rand_core::Rng;
 
 use crate::TlsError;
 use crate::config::{TlsCipherSuite, TlsConfig};
@@ -49,12 +50,12 @@ where
             config,
             random,
             cipher_suite: PhantomData,
-            secret: EphemeralSecret::random(&mut provider.rng()),
+            secret: EphemeralSecret::generate_from_rng(&mut provider.rng()),
         }
     }
 
     pub(crate) fn encode(&self, buf: &mut CryptoBuffer<'_>) -> Result<(), TlsError> {
-        let public_key = EncodedPoint::from(&self.secret.public_key());
+        let public_key = Sec1Point::from(&self.secret.public_key());
         let public_key = public_key.as_ref();
 
         buf.push_u16(LEGACY_VERSION)

--- a/src/handshake/finished.rs
+++ b/src/handshake/finished.rs
@@ -1,24 +1,24 @@
+use core::fmt::{Debug, Formatter};
+
+use digest::array::{Array, ArraySize};
+
 use crate::TlsError;
 use crate::buffer::CryptoBuffer;
 use crate::parse_buffer::ParseBuffer;
-use core::fmt::{Debug, Formatter};
-//use digest::generic_array::{ArrayLength, GenericArray};
-use generic_array::{ArrayLength, GenericArray};
-// use heapless::Vec;
 
-pub struct Finished<N: ArrayLength<u8>> {
-    pub verify: GenericArray<u8, N>,
-    pub hash: Option<GenericArray<u8, N>>,
+pub struct Finished<N: ArraySize> {
+    pub verify: Array<u8, N>,
+    pub hash: Option<Array<u8, N>>,
 }
 
 #[cfg(feature = "defmt")]
-impl<N: ArrayLength<u8>> defmt::Format for Finished<N> {
+impl<N: ArraySize> defmt::Format for Finished<N> {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(f, "verify length:{}", &self.verify.len());
     }
 }
 
-impl<N: ArrayLength<u8>> Debug for Finished<N> {
+impl<N: ArraySize> Debug for Finished<N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Finished")
             .field("verify", &self.hash)
@@ -26,12 +26,12 @@ impl<N: ArrayLength<u8>> Debug for Finished<N> {
     }
 }
 
-impl<N: ArrayLength<u8>> Finished<N> {
+impl<N: ArraySize> Finished<N> {
     pub fn parse(buf: &mut ParseBuffer, _len: u32) -> Result<Self, TlsError> {
         // info!("finished len: {}", len);
-        let mut verify = GenericArray::default();
+        let mut verify = Array::default();
         buf.fill(&mut verify)?;
-        //let hash = GenericArray::from_slice()
+        //let hash = Array::from_slice()
         //let hash: Result<Vec<u8, _>, ()> = buf
         //.slice(len as usize)
         //.map_err(|_| TlsError::InvalidHandshake)?

--- a/src/key_schedule.rs
+++ b/src/key_schedule.rs
@@ -1,23 +1,22 @@
+use digest::OutputSizeUser;
+use digest::array::{Array, ArraySize};
+use digest::typenum::Unsigned;
+use hmac::{KeyInit, Mac, SimpleHmac};
+use sha2::Digest;
+
 use crate::handshake::binder::PskBinder;
 use crate::handshake::finished::Finished;
 use crate::{TlsError, config::TlsCipherSuite};
-use digest::OutputSizeUser;
-use digest::generic_array::ArrayLength;
-use hmac::{Mac, SimpleHmac};
-use sha2::Digest;
-use sha2::digest::generic_array::{GenericArray, typenum::Unsigned};
 
 pub type HashOutputSize<CipherSuite> =
     <<CipherSuite as TlsCipherSuite>::Hash as OutputSizeUser>::OutputSize;
+pub type LabelBufferSize<CipherSuite> = <CipherSuite as TlsCipherSuite>::LabelBufferSize;
 
-pub type IvArray<CipherSuite> = GenericArray<u8, <CipherSuite as TlsCipherSuite>::IvLen>;
-pub type KeyArray<CipherSuite> = GenericArray<u8, <CipherSuite as TlsCipherSuite>::KeyLen>;
-pub type HashArray<CipherSuite> = GenericArray<u8, HashOutputSize<CipherSuite>>;
+pub type IvArray<CipherSuite> = Array<u8, <CipherSuite as TlsCipherSuite>::IvLen>;
+pub type KeyArray<CipherSuite> = Array<u8, <CipherSuite as TlsCipherSuite>::KeyLen>;
+pub type HashArray<CipherSuite> = Array<u8, HashOutputSize<CipherSuite>>;
 
-type Hkdf<CipherSuite> = hkdf::Hkdf<
-    <CipherSuite as TlsCipherSuite>::Hash,
-    SimpleHmac<<CipherSuite as TlsCipherSuite>::Hash>,
->;
+type Hkdf<CipherSuite> = hkdf::GenericHkdf<SimpleHmac<<CipherSuite as TlsCipherSuite>::Hash>>;
 
 enum Secret<CipherSuite>
 where
@@ -42,47 +41,43 @@ where
         }
     }
 
-    fn make_expanded_hkdf_label<N: ArrayLength<u8>>(
+    fn make_expanded_hkdf_label<N: ArraySize>(
         &self,
         label: &[u8],
         context_type: ContextType<CipherSuite>,
-    ) -> Result<GenericArray<u8, N>, TlsError> {
+    ) -> Result<Array<u8, N>, TlsError> {
+        fn copy_slice(dest: &mut [u8], src: &[u8]) -> usize {
+            let len = src.len();
+            dest[..len].copy_from_slice(src);
+            len
+        }
+
         //info!("make label {:?} {}", label, len);
-        // Max label buffer: hash_output (up to 48 for SHA-384) + 12 (longest label) + 10 (overhead) = 70
-        let mut hkdf_label = heapless::Vec::<u8, 70>::new();
-        hkdf_label
-            .extend_from_slice(&N::to_u16().to_be_bytes())
-            .map_err(|_| TlsError::InternalError)?;
+
+        let mut hkdf_label = Array::<u8, LabelBufferSize<CipherSuite>>::from_fn(|_| 0);
+        let mut i = 0;
+
+        i += copy_slice(&mut hkdf_label[i..], &N::to_u16().to_be_bytes());
 
         let label_len = 6 + label.len() as u8;
-        hkdf_label
-            .extend_from_slice(&label_len.to_be_bytes())
-            .map_err(|_| TlsError::InternalError)?;
-        hkdf_label
-            .extend_from_slice(b"tls13 ")
-            .map_err(|_| TlsError::InternalError)?;
-        hkdf_label
-            .extend_from_slice(label)
-            .map_err(|_| TlsError::InternalError)?;
+        i += copy_slice(&mut hkdf_label[i..], &label_len.to_be_bytes());
+        i += copy_slice(&mut hkdf_label[i..], b"tls13 ");
+        i += copy_slice(&mut hkdf_label[i..], label);
 
         match context_type {
             ContextType::None => {
-                hkdf_label.push(0).map_err(|_| TlsError::InternalError)?;
+                i += copy_slice(&mut hkdf_label[i..], &[0]);
             }
             ContextType::Hash(context) => {
-                hkdf_label
-                    .extend_from_slice(&(context.len() as u8).to_be_bytes())
-                    .map_err(|_| TlsError::InternalError)?;
-                hkdf_label
-                    .extend_from_slice(&context)
-                    .map_err(|_| TlsError::InternalError)?;
+                i += copy_slice(&mut hkdf_label[i..], &[context.len() as u8]);
+                i += copy_slice(&mut hkdf_label[i..], &context);
             }
         }
 
-        let mut okm = GenericArray::default();
+        let mut okm = Array::default();
         //info!("label {:x?}", label);
         self.as_ref()?
-            .expand(&hkdf_label, &mut okm)
+            .expand(&hkdf_label[..i], &mut okm)
             .map_err(|_| TlsError::CryptoError)?;
         //info!("expand {:x?}", okm);
         Ok(okm)
@@ -103,7 +98,7 @@ where
 {
     fn new() -> Self {
         Self {
-            secret: GenericArray::default(),
+            secret: Array::default(),
             hkdf: Secret::Uninitialized,
         }
     }
@@ -300,7 +295,7 @@ where
         //info!("counter = {:x?}", counter);
         // info!("iv = {:x?}", iv);
 
-        let mut nonce = GenericArray::default();
+        let mut nonce = Array::default();
 
         for (index, (l, r)) in iv[0..CipherSuite::IvLen::to_usize()]
             .iter()
@@ -315,9 +310,9 @@ where
         nonce
     }
 
-    fn pad<N: ArrayLength<u8>>(input: &[u8]) -> GenericArray<u8, N> {
+    fn pad<N: ArraySize>(input: &[u8]) -> Array<u8, N> {
         // info!("padding input = {:x?}", input);
-        let mut padded = GenericArray::default();
+        let mut padded = Array::default();
         for (index, byte) in input.iter().rev().enumerate() {
             /*info!(
                 "{} pad {}={:x?}",
@@ -331,7 +326,7 @@ where
     }
 
     fn zero() -> HashArray<CipherSuite> {
-        GenericArray::default()
+        Array::default()
     }
 
     // Initializes the early secrets with a callback for any PSK binders

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 ```
 use embedded_tls::*;
 use embedded_io_adapters::tokio_1::FromTokio;
-use rand::rngs::OsRng;
 use tokio::net::TcpStream;
 
 #[tokio::main]
@@ -38,7 +37,7 @@ async fn main() {
     // otherwise, use embedded_tls::webpki::CertVerifier, which only works on std for now.
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .await
     .expect("error establishing TLS connection");
@@ -76,7 +75,7 @@ mod write_buffer;
 pub use config::UnsecureProvider;
 pub use extensions::extension_data::signature_algorithms::SignatureScheme;
 pub use handshake::certificate_verify::CertificateVerify;
-pub use rand_core::{CryptoRng, CryptoRngCore};
+pub use rand_core::CryptoRng;
 
 #[cfg(feature = "webpki")]
 pub mod webpki;
@@ -142,7 +141,7 @@ impl embedded_io::Error for TlsError {
 
 impl core::fmt::Display for TlsError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{self:?}")
+        core::fmt::Debug::fmt(self, f)
     }
 }
 

--- a/src/parse_buffer.rs
+++ b/src/parse_buffer.rs
@@ -1,5 +1,6 @@
-use crate::TlsError;
 use heapless::{CapacityError, Vec};
+
+use crate::TlsError;
 
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -176,6 +176,7 @@ fn verify_signature(
     match verify.signature_scheme {
         SignatureScheme::EcdsaSecp256r1Sha256 => {
             use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+
             let verifying_key =
                 VerifyingKey::from_sec1_bytes(public_key).map_err(|_| TlsError::DecodeError)?;
             let signature =
@@ -185,6 +186,7 @@ fn verify_signature(
         #[cfg(feature = "p384")]
         SignatureScheme::EcdsaSecp384r1Sha384 => {
             use p384::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+
             let verifying_key =
                 VerifyingKey::from_sec1_bytes(public_key).map_err(|_| TlsError::DecodeError)?;
             let signature =
@@ -193,10 +195,12 @@ fn verify_signature(
         }
         #[cfg(feature = "ed25519")]
         SignatureScheme::Ed25519 => {
-            use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+            use ed25519_dalek::{PUBLIC_KEY_LENGTH, Signature, Verifier, VerifyingKey};
+
+            let public_key = <&[u8; PUBLIC_KEY_LENGTH]>::try_from(public_key)
+                .map_err(|_| TlsError::DecodeError)?;
             let verifying_key: VerifyingKey =
-                VerifyingKey::from_bytes(public_key.try_into().unwrap())
-                    .map_err(|_| TlsError::DecodeError)?;
+                VerifyingKey::from_bytes(public_key).map_err(|_| TlsError::DecodeError)?;
             let signature =
                 Signature::try_from(verify.signature).map_err(|_| TlsError::DecodeError)?;
             verified = verifying_key.verify(message, &signature).is_ok();
@@ -211,7 +215,8 @@ fn verify_signature(
             };
             use sha2::Sha256;
 
-            let der_pubkey = RsaPublicKey::from_pkcs1_der(public_key).unwrap();
+            let der_pubkey =
+                RsaPublicKey::from_pkcs1_der(public_key).map_err(|_| TlsError::DecodeError)?;
             let verifying_key = VerifyingKey::<Sha256>::from(der_pubkey);
 
             let signature =
@@ -338,6 +343,7 @@ fn verify_certificate(
         match parsed_certificate.signature_algorithm {
             ECDSA_SHA256 => {
                 use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+
                 let verifying_key = VerifyingKey::from_sec1_bytes(ca_public_key)
                     .map_err(|_| TlsError::DecodeError)?;
 
@@ -354,6 +360,7 @@ fn verify_certificate(
             #[cfg(feature = "p384")]
             ECDSA_SHA384 => {
                 use p384::ecdsa::{Signature, VerifyingKey, signature::Verifier};
+
                 let verifying_key = VerifyingKey::from_sec1_bytes(ca_public_key)
                     .map_err(|_| TlsError::DecodeError)?;
 
@@ -369,10 +376,12 @@ fn verify_certificate(
             }
             #[cfg(feature = "ed25519")]
             ED25519 => {
-                use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+                use ed25519_dalek::{PUBLIC_KEY_LENGTH, Signature, Verifier, VerifyingKey};
+
+                let ca_public_key = <&[u8; PUBLIC_KEY_LENGTH]>::try_from(ca_public_key)
+                    .map_err(|_| TlsError::DecodeError)?;
                 let verifying_key: VerifyingKey =
-                    VerifyingKey::from_bytes(ca_public_key.try_into().unwrap())
-                        .map_err(|_| TlsError::DecodeError)?;
+                    VerifyingKey::from_bytes(ca_public_key).map_err(|_| TlsError::DecodeError)?;
 
                 let signature = Signature::try_from(
                     parsed_certificate
@@ -387,20 +396,21 @@ fn verify_certificate(
             #[cfg(feature = "rsa")]
             a if a == RSA_PKCS1_SHA256 => {
                 use rsa::{
+                    RsaPublicKey,
                     pkcs1::DecodeRsaPublicKey,
                     pkcs1v15::{Signature, VerifyingKey},
                     signature::Verifier,
                 };
                 use sha2::Sha256;
 
-                let verifying_key =
-                    VerifyingKey::<Sha256>::from_pkcs1_der(ca_public_key).map_err(|e| {
-                        #[cfg(feature = "defmt")]
-                        error!("VerifyingKey: {:?}", Debug2Format(&e));
-                        #[cfg(not(feature = "defmt"))]
-                        error!("VerifyingKey: {}", e);
-                        TlsError::DecodeError
-                    })?;
+                let der_pubkey = RsaPublicKey::from_pkcs1_der(ca_public_key).map_err(|e| {
+                    #[cfg(feature = "defmt")]
+                    error!("VerifyingKey: {:?}", Debug2Format(&e));
+                    #[cfg(not(feature = "defmt"))]
+                    error!("VerifyingKey: {}", e);
+                    TlsError::DecodeError
+                })?;
+                let verifying_key = VerifyingKey::<Sha256>::from(der_pubkey);
 
                 let signature = Signature::try_from(
                     parsed_certificate
@@ -421,14 +431,16 @@ fn verify_certificate(
             #[cfg(feature = "rsa")]
             a if a == RSA_PKCS1_SHA384 => {
                 use rsa::{
+                    RsaPublicKey,
                     pkcs1::DecodeRsaPublicKey,
                     pkcs1v15::{Signature, VerifyingKey},
                     signature::Verifier,
                 };
                 use sha2::Sha384;
 
-                let verifying_key = VerifyingKey::<Sha384>::from_pkcs1_der(ca_public_key)
+                let der_pubkey = RsaPublicKey::from_pkcs1_der(ca_public_key)
                     .map_err(|_| TlsError::DecodeError)?;
+                let verifying_key = VerifyingKey::<Sha384>::from(der_pubkey);
 
                 let signature = Signature::try_from(
                     parsed_certificate
@@ -443,14 +455,16 @@ fn verify_certificate(
             #[cfg(feature = "rsa")]
             a if a == RSA_PKCS1_SHA512 => {
                 use rsa::{
+                    RsaPublicKey,
                     pkcs1::DecodeRsaPublicKey,
                     pkcs1v15::{Signature, VerifyingKey},
                     signature::Verifier,
                 };
                 use sha2::Sha512;
 
-                let verifying_key = VerifyingKey::<Sha512>::from_pkcs1_der(ca_public_key)
+                let der_pubkey = RsaPublicKey::from_pkcs1_der(ca_public_key)
                     .map_err(|_| TlsError::DecodeError)?;
+                let verifying_key = VerifyingKey::<Sha512>::from(der_pubkey);
 
                 let signature = Signature::try_from(
                     parsed_certificate

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,3 +1,5 @@
+use core::fmt::Debug;
+
 use crate::TlsError;
 use crate::application_data::ApplicationData;
 use crate::change_cipher_spec::ChangeCipherSpec;
@@ -11,14 +13,12 @@ use crate::{
     alert::{Alert, AlertDescription, AlertLevel},
     parse_buffer::ParseBuffer,
 };
-use core::fmt::Debug;
 
 pub type Encrypted = bool;
 
 #[allow(clippy::large_enum_variant)]
 pub enum ClientRecord<'config, 'a, CipherSuite>
 where
-    // N: ArrayLength<u8>,
     CipherSuite: TlsCipherSuite,
 {
     Handshake(ClientHandshake<'config, 'a, CipherSuite>, Encrypted),
@@ -80,7 +80,6 @@ impl ClientRecordHeader {
 
 impl<'config, CipherSuite> ClientRecord<'config, '_, CipherSuite>
 where
-    //N: ArrayLength<u8>,
     CipherSuite: TlsCipherSuite,
 {
     pub fn header(&self) -> ClientRecordHeader {

--- a/src/webpki.rs
+++ b/src/webpki.rs
@@ -8,12 +8,17 @@ use crate::handshake::{
     certificate_verify::CertificateVerifyRef,
 };
 use core::marker::PhantomData;
+use core::time::Duration;
 use digest::Digest;
 use heapless::Vec;
+
 #[cfg(all(not(feature = "alloc"), feature = "webpki"))]
-impl TryInto<&'static webpki::SignatureAlgorithm> for SignatureScheme {
+impl TryInto<&'static dyn pki_types::SignatureVerificationAlgorithm> for SignatureScheme {
     type Error = TlsError;
-    fn try_into(self) -> Result<&'static webpki::SignatureAlgorithm, Self::Error> {
+
+    fn try_into(
+        self,
+    ) -> Result<&'static dyn pki_types::SignatureVerificationAlgorithm, Self::Error> {
         // TODO: support other schemes via 'alloc' feature
         #[allow(clippy::match_same_arms)] // Style
         match self {
@@ -22,8 +27,8 @@ impl TryInto<&'static webpki::SignatureAlgorithm> for SignatureScheme {
             | SignatureScheme::RsaPkcs1Sha512 => Err(TlsError::InvalidSignatureScheme),
 
             /* ECDSA algorithms */
-            SignatureScheme::EcdsaSecp256r1Sha256 => Ok(&webpki::ECDSA_P256_SHA256),
-            SignatureScheme::EcdsaSecp384r1Sha384 => Ok(&webpki::ECDSA_P384_SHA384),
+            SignatureScheme::EcdsaSecp256r1Sha256 => Ok(webpki::ring::ECDSA_P256_SHA256),
+            SignatureScheme::EcdsaSecp384r1Sha384 => Ok(webpki::ring::ECDSA_P384_SHA384),
             SignatureScheme::EcdsaSecp521r1Sha512 => Err(TlsError::InvalidSignatureScheme),
 
             /* RSASSA-PSS algorithms with public key OID rsaEncryption */
@@ -32,7 +37,7 @@ impl TryInto<&'static webpki::SignatureAlgorithm> for SignatureScheme {
             | SignatureScheme::RsaPssRsaeSha512 => Err(TlsError::InvalidSignatureScheme),
 
             /* EdDSA algorithms */
-            SignatureScheme::Ed25519 => Ok(&webpki::ED25519),
+            SignatureScheme::Ed25519 => Ok(webpki::ring::ED25519),
             SignatureScheme::Ed448
             | SignatureScheme::Sha224Ecdsa
             | SignatureScheme::Sha224Rsa
@@ -62,26 +67,35 @@ impl TryInto<&'static webpki::SignatureAlgorithm> for SignatureScheme {
 }
 
 #[cfg(all(feature = "alloc", feature = "webpki"))]
-impl TryInto<&'static webpki::SignatureAlgorithm> for SignatureScheme {
+impl TryInto<&'static dyn pki_types::SignatureVerificationAlgorithm> for SignatureScheme {
     type Error = TlsError;
-    fn try_into(self) -> Result<&'static webpki::SignatureAlgorithm, Self::Error> {
+
+    fn try_into(
+        self,
+    ) -> Result<&'static dyn pki_types::SignatureVerificationAlgorithm, Self::Error> {
         match self {
-            SignatureScheme::RsaPkcs1Sha256 => Ok(&webpki::RSA_PKCS1_2048_8192_SHA256),
-            SignatureScheme::RsaPkcs1Sha384 => Ok(&webpki::RSA_PKCS1_2048_8192_SHA384),
-            SignatureScheme::RsaPkcs1Sha512 => Ok(&webpki::RSA_PKCS1_2048_8192_SHA512),
+            SignatureScheme::RsaPkcs1Sha256 => Ok(webpki::ring::RSA_PKCS1_2048_8192_SHA256),
+            SignatureScheme::RsaPkcs1Sha384 => Ok(webpki::ring::RSA_PKCS1_2048_8192_SHA384),
+            SignatureScheme::RsaPkcs1Sha512 => Ok(webpki::ring::RSA_PKCS1_2048_8192_SHA512),
 
             /* ECDSA algorithms */
-            SignatureScheme::EcdsaSecp256r1Sha256 => Ok(&webpki::ECDSA_P256_SHA256),
-            SignatureScheme::EcdsaSecp384r1Sha384 => Ok(&webpki::ECDSA_P384_SHA384),
+            SignatureScheme::EcdsaSecp256r1Sha256 => Ok(webpki::ring::ECDSA_P256_SHA256),
+            SignatureScheme::EcdsaSecp384r1Sha384 => Ok(webpki::ring::ECDSA_P384_SHA384),
             SignatureScheme::EcdsaSecp521r1Sha512 => Err(TlsError::InvalidSignatureScheme),
 
             /* RSASSA-PSS algorithms with public key OID rsaEncryption */
-            SignatureScheme::RsaPssRsaeSha256 => Ok(&webpki::RSA_PSS_2048_8192_SHA256_LEGACY_KEY),
-            SignatureScheme::RsaPssRsaeSha384 => Ok(&webpki::RSA_PSS_2048_8192_SHA384_LEGACY_KEY),
-            SignatureScheme::RsaPssRsaeSha512 => Ok(&webpki::RSA_PSS_2048_8192_SHA512_LEGACY_KEY),
+            SignatureScheme::RsaPssRsaeSha256 => {
+                Ok(webpki::ring::RSA_PSS_2048_8192_SHA256_LEGACY_KEY)
+            }
+            SignatureScheme::RsaPssRsaeSha384 => {
+                Ok(webpki::ring::RSA_PSS_2048_8192_SHA384_LEGACY_KEY)
+            }
+            SignatureScheme::RsaPssRsaeSha512 => {
+                Ok(webpki::ring::RSA_PSS_2048_8192_SHA512_LEGACY_KEY)
+            }
 
             /* EdDSA algorithms */
-            SignatureScheme::Ed25519 => Ok(&webpki::ED25519),
+            SignatureScheme::Ed25519 => Ok(webpki::ring::ED25519),
             SignatureScheme::Ed448 => Err(TlsError::InvalidSignatureScheme),
 
             SignatureScheme::Sha224Ecdsa => Err(TlsError::InvalidSignatureScheme),
@@ -110,12 +124,12 @@ impl TryInto<&'static webpki::SignatureAlgorithm> for SignatureScheme {
     }
 }
 
-static ALL_SIGALGS: &[&webpki::SignatureAlgorithm] = &[
-    &webpki::ECDSA_P256_SHA256,
-    &webpki::ECDSA_P256_SHA384,
-    &webpki::ECDSA_P384_SHA256,
-    &webpki::ECDSA_P384_SHA384,
-    &webpki::ED25519,
+static ALL_SIGALGS: &[&dyn pki_types::SignatureVerificationAlgorithm] = &[
+    webpki::ring::ECDSA_P256_SHA256,
+    webpki::ring::ECDSA_P256_SHA384,
+    webpki::ring::ECDSA_P384_SHA256,
+    webpki::ring::ECDSA_P384_SHA384,
+    webpki::ring::ED25519,
 ];
 
 pub struct CertVerifier<'a, CipherSuite, Clock, const CERT_SIZE: usize>
@@ -196,7 +210,9 @@ fn verify_signature(
     if !certificate.entries.is_empty() {
         // TODO: Support intermediates...
         if let CertificateEntryRef::X509(certificate) = certificate.entries[0] {
-            let cert = webpki::EndEntityCert::try_from(certificate).map_err(|e| {
+            let certificate = pki_types::CertificateDer::from_slice(certificate);
+
+            let cert = webpki::EndEntityCert::try_from(&certificate).map_err(|e| {
                 warn!("Error loading cert: {:?}", e);
                 TlsError::DecodeError
             })?;
@@ -232,7 +248,9 @@ fn verify_certificate(
     let mut verified = false;
     let mut host_verified = false;
     if let Certificate::X509(ca) = ca {
-        let trust = webpki::TrustAnchor::try_from_cert_der(ca).map_err(|e| {
+        let ca = pki_types::CertificateDer::from_slice(ca);
+
+        let trust = webpki::anchor_from_trusted_cert(&ca).map_err(|e| {
             warn!("Error loading CA: {:?}", e);
             TlsError::DecodeError
         })?;
@@ -242,16 +260,18 @@ fn verify_certificate(
         if !certificate.entries.is_empty() {
             // TODO: Support intermediates...
             if let CertificateEntryRef::X509(certificate) = certificate.entries[0] {
-                let cert = webpki::EndEntityCert::try_from(certificate).map_err(|e| {
+                let certificate = pki_types::CertificateDer::from_slice(certificate);
+
+                let cert = webpki::EndEntityCert::try_from(&certificate).map_err(|e| {
                     warn!("Error loading cert: {:?}", e);
                     TlsError::DecodeError
                 })?;
 
                 let time = if let Some(now) = now {
-                    webpki::Time::from_seconds_since_unix_epoch(now)
+                    pki_types::UnixTime::since_unix_epoch(Duration::from_secs(now))
                 } else {
                     // If no clock is provided, the validity check will fail
-                    webpki::Time::from_seconds_since_unix_epoch(0)
+                    pki_types::UnixTime::since_unix_epoch(Duration::ZERO)
                 };
                 info!("Certificate is loaded!");
                 match cert.verify_for_usage(
@@ -260,17 +280,18 @@ fn verify_certificate(
                     &[],
                     time,
                     webpki::KeyUsage::server_auth(),
-                    &[],
+                    None,
+                    None,
                 ) {
-                    Ok(()) => verified = true,
+                    Ok(_) => verified = true,
                     Err(e) => {
                         warn!("Error verifying certificate: {:?}", e);
                     }
                 }
 
                 if let Some(server_name) = verify_host {
-                    match webpki::SubjectNameRef::try_from_ascii(server_name.as_bytes()) {
-                        Ok(subject) => match cert.verify_is_valid_for_subject_name(subject) {
+                    match pki_types::ServerName::try_from(server_name) {
+                        Ok(subject) => match cert.verify_is_valid_for_subject_name(&subject) {
                             Ok(()) => host_verified = true,
                             Err(e) => {
                                 warn!("Error verifying host: {:?}", e);

--- a/tests/client_cert_test.rs
+++ b/tests/client_cert_test.rs
@@ -1,29 +1,23 @@
+use std::net::SocketAddr;
+use std::sync::{Arc, OnceLock};
+
 use ecdsa::elliptic_curve::SecretKey;
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_tls::{Certificate, CryptoProvider, SignatureScheme};
 use p256::ecdsa::SigningKey;
-use rand::rngs::OsRng;
-use rand_core::CryptoRngCore;
-use rustls::server::AllowAnyAuthenticatedClient;
-use std::net::SocketAddr;
-use std::sync::Once;
+use rand_core::CryptoRng;
+use rustls::server::WebPkiClientVerifier;
 
 mod tlsserver;
 
-static LOG_INIT: Once = Once::new();
-static INIT: Once = Once::new();
-static mut ADDR: Option<SocketAddr> = None;
-
-fn init_log() {
-    LOG_INIT.call_once(|| {
-        env_logger::init();
-    });
-}
+static ADDR: OnceLock<SocketAddr> = OnceLock::new();
 
 fn setup() -> SocketAddr {
     use mio::net::TcpListener;
-    init_log();
-    INIT.call_once(|| {
+
+    *ADDR.get_or_init(|| {
+        env_logger::init();
+
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
 
         let listener = TcpListener::bind(addr).expect("cannot listen on port");
@@ -34,8 +28,6 @@ fn setup() -> SocketAddr {
         std::thread::spawn(move || {
             use tlsserver::*;
 
-            let versions = &[&rustls::version::TLS13];
-
             let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
 
             let ca = load_certs(&test_dir.join("data").join("ca-cert.pem"));
@@ -43,48 +35,43 @@ fn setup() -> SocketAddr {
             let privkey = load_private_key(&test_dir.join("data").join("server-key.pem"));
 
             let mut client_auth_roots = rustls::RootCertStore::empty();
-            for root in ca.iter() {
+            for root in ca.into_iter() {
                 client_auth_roots.add(root).unwrap()
             }
 
-            let client_cert_verifier = AllowAnyAuthenticatedClient::new(client_auth_roots);
+            let client_cert_verifier = WebPkiClientVerifier::builder(Arc::new(client_auth_roots))
+                .build()
+                .unwrap();
 
             let config = rustls::ServerConfig::builder()
-                .with_cipher_suites(rustls::ALL_CIPHER_SUITES)
-                .with_kx_groups(&rustls::ALL_KX_GROUPS)
-                .with_protocol_versions(versions)
-                .unwrap()
-                .with_client_cert_verifier(client_cert_verifier.boxed())
+                .with_client_cert_verifier(client_cert_verifier)
                 .with_single_cert(certs, privkey)
                 .unwrap();
 
             run_with_config(listener, config);
         });
-        #[allow(static_mut_refs)]
-        unsafe {
-            ADDR.replace(addr)
-        };
-    });
-    unsafe { ADDR.unwrap() }
+
+        addr
+    })
 }
 
-struct Provider<'a> {
-    rng: OsRng,
+struct Provider<'a, RNG> {
+    rng: RNG,
     priv_key: &'a [u8],
     client_cert: Option<Certificate<&'a [u8]>>,
 }
 
-impl CryptoProvider for Provider<'_> {
+impl<RNG: CryptoRng> CryptoProvider for Provider<'_, RNG> {
     type CipherSuite = embedded_tls::Aes128GcmSha256;
     type Signature = p256::ecdsa::DerSignature;
 
-    fn rng(&mut self) -> impl CryptoRngCore {
+    fn rng(&mut self) -> impl CryptoRng {
         &mut self.rng
     }
 
     fn signer(
         &mut self,
-    ) -> Result<(impl signature::SignerMut<Self::Signature>, SignatureScheme), embedded_tls::TlsError>
+    ) -> Result<(impl signature::Signer<Self::Signature>, SignatureScheme), embedded_tls::TlsError>
     {
         let secret_key = SecretKey::from_sec1_der(self.priv_key)
             .map_err(|_| embedded_tls::TlsError::InvalidPrivateKey)?;
@@ -130,7 +117,7 @@ async fn test_client_certificate_auth() {
     log::info!("SIZE of connection is {}", core::mem::size_of_val(&tls));
 
     let mut provider = Provider {
-        rng: OsRng,
+        rng: rand::rng(),
         priv_key: &private_key_der,
         client_cert: Some(Certificate::X509(&client_cert_der)),
     };

--- a/tests/client_test.rs
+++ b/tests/client_test.rs
@@ -1,17 +1,18 @@
 #![macro_use]
+
+use std::net::SocketAddr;
+use std::sync::Once;
+use std::sync::OnceLock;
+
 use embedded_io::BufRead as _;
 use embedded_io_adapters::{std::FromStd, tokio_1::FromTokio};
 use embedded_io_async::BufRead as _;
 use embedded_io_async::Write;
-use rand::rngs::OsRng;
-use std::net::SocketAddr;
-use std::sync::Once;
 
 mod tlsserver;
 
 static LOG_INIT: Once = Once::new();
-static INIT: Once = Once::new();
-static mut ADDR: Option<SocketAddr> = None;
+static ADDR: OnceLock<SocketAddr> = OnceLock::new();
 
 fn init_log() {
     LOG_INIT.call_once(|| {
@@ -21,8 +22,10 @@ fn init_log() {
 
 fn setup() -> SocketAddr {
     use mio::net::TcpListener;
+
     init_log();
-    INIT.call_once(|| {
+
+    *ADDR.get_or_init(|| {
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
 
         let listener = TcpListener::bind(addr).expect("cannot listen on port");
@@ -33,12 +36,9 @@ fn setup() -> SocketAddr {
         std::thread::spawn(move || {
             tlsserver::run(listener);
         });
-        #[allow(static_mut_refs)]
-        unsafe {
-            ADDR.replace(addr)
-        };
-    });
-    unsafe { ADDR.unwrap() }
+
+        addr
+    })
 }
 
 #[tokio::test]
@@ -65,7 +65,7 @@ async fn test_google() {
 
     let open_fut = tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ));
     log::info!("SIZE of open fut is {}", core::mem::size_of_val(&open_fut));
     open_fut.await.expect("error establishing TLS connection");
@@ -111,7 +111,7 @@ async fn test_ping() {
 
     let open_fut = tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ));
     log::info!("SIZE of open fut is {}", core::mem::size_of_val(&open_fut));
     open_fut.await.expect("error establishing TLS connection");
@@ -176,7 +176,7 @@ async fn test_ping_nocopy() {
 
     let open_fut = tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ));
     log::info!("SIZE of open fut is {}", core::mem::size_of_val(&open_fut));
     open_fut.await.expect("error establishing TLS connection");
@@ -241,7 +241,7 @@ async fn test_ping_nocopy_bufread() {
     );
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .await
     .expect("error establishing TLS connection");
@@ -284,7 +284,7 @@ fn test_blocking_ping() {
     );
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .expect("error establishing TLS connection");
     log::info!("Established");
@@ -333,7 +333,7 @@ fn test_blocking_ping_nocopy() {
     );
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .expect("error establishing TLS connection");
     log::info!("Established");
@@ -376,7 +376,7 @@ fn test_blocking_ping_nocopy_bufread() {
     );
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .expect("error establishing TLS connection");
     log::info!("Established");

--- a/tests/early_data_test.rs
+++ b/tests/early_data_test.rs
@@ -1,18 +1,19 @@
 #![macro_use]
+
+use std::net::SocketAddr;
+use std::sync::OnceLock;
+
 use embedded_io::{Read, Write};
 use embedded_io_adapters::std::FromStd;
-use rand_core::OsRng;
-use std::net::SocketAddr;
-use std::sync::Once;
 
 mod tlsserver;
 
-static INIT: Once = Once::new();
-static mut ADDR: Option<SocketAddr> = None;
+static ADDR: OnceLock<SocketAddr> = OnceLock::new();
 
 fn setup() -> SocketAddr {
     use mio::net::TcpListener;
-    INIT.call_once(|| {
+
+    *ADDR.get_or_init(|| {
         env_logger::init();
 
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
@@ -25,18 +26,12 @@ fn setup() -> SocketAddr {
         std::thread::spawn(move || {
             use tlsserver::*;
 
-            let versions = &[&rustls::version::TLS13];
-
             let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
 
             let certs = load_certs(&test_dir.join("data").join("server-cert.pem"));
             let privkey = load_private_key(&test_dir.join("data").join("server-key.pem"));
 
             let mut config = rustls::ServerConfig::builder()
-                .with_cipher_suites(rustls::ALL_CIPHER_SUITES)
-                .with_kx_groups(&rustls::ALL_KX_GROUPS)
-                .with_protocol_versions(versions)
-                .unwrap()
                 .with_no_client_auth()
                 .with_single_cert(certs, privkey)
                 .unwrap();
@@ -45,12 +40,9 @@ fn setup() -> SocketAddr {
 
             run_with_config(listener, config);
         });
-        #[allow(static_mut_refs)]
-        unsafe {
-            ADDR.replace(addr)
-        };
-    });
-    unsafe { ADDR.unwrap() }
+
+        addr
+    })
 }
 
 #[test]
@@ -74,7 +66,7 @@ fn early_data_ignored() {
 
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .expect("error establishing TLS connection");
 

--- a/tests/psk_test.rs
+++ b/tests/psk_test.rs
@@ -1,12 +1,13 @@
 #![macro_use]
-use embedded_io_adapters::tokio_1::FromTokio;
-use embedded_tls::*;
-use openssl::ssl;
-use rand::rngs::OsRng;
+
 use std::io::{Read, Write};
 use std::net::SocketAddr;
 use std::net::TcpListener;
 use std::sync::Once;
+
+use embedded_io_adapters::tokio_1::FromTokio;
+use embedded_tls::*;
+use openssl::ssl;
 use tokio::net::TcpStream;
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
@@ -84,7 +85,7 @@ async fn test_psk_open() {
         assert!(
             tls.open(TlsContext::new(
                 &config,
-                UnsecureProvider::new::<Aes128GcmSha256>(OsRng)
+                UnsecureProvider::new::<Aes128GcmSha256>(rand::rng())
             ))
             .await
             .is_ok()

--- a/tests/rustpki_rsa_test.rs
+++ b/tests/rustpki_rsa_test.rs
@@ -3,14 +3,13 @@ use digest::FixedOutputReset;
 use embedded_io_adapters::tokio_1::FromTokio;
 use embedded_tls::pki::CertVerifier;
 use embedded_tls::{Aes128GcmSha256, CryptoProvider, SignatureScheme, TlsError, TlsVerifier};
-use rand_core::{CryptoRngCore, OsRng};
+use rand_core::CryptoRng;
 use rsa::pkcs8::DecodePrivateKey;
-use rustls::server::AllowAnyAnonymousOrAuthenticatedClient;
+use rustls::server::WebPkiClientVerifier;
 use sha2::{Digest, Sha256};
 use signature::RandomizedSigner;
-use signature::SignerMut;
 use std::net::SocketAddr;
-use std::sync::Once;
+use std::sync::{Arc, Once};
 use std::time::SystemTime;
 
 mod tlsserver;
@@ -19,32 +18,29 @@ static LOG_INIT: Once = Once::new();
 static INIT: Once = Once::new();
 static mut ADDR: Option<SocketAddr> = None;
 
-struct RsaPssSigningKey<D: Digest, R: CryptoRngCore> {
-    rng: R,
+struct RsaPssSigningKey<D: Digest> {
     key: rsa::pss::SigningKey<D>,
 }
 
-impl<D: Digest + FixedOutputReset, R: CryptoRngCore> SignerMut<Box<[u8]>>
-    for RsaPssSigningKey<D, R>
-{
-    fn try_sign(&mut self, msg: &[u8]) -> Result<Box<[u8]>, rsa::signature::Error> {
-        let signature = self.key.try_sign_with_rng(&mut self.rng, msg)?;
+impl<D: Digest + FixedOutputReset> signature::Signer<Box<[u8]>> for RsaPssSigningKey<D> {
+    fn try_sign(&self, msg: &[u8]) -> Result<Box<[u8]>, rsa::signature::Error> {
+        let signature = self.key.try_sign_with_rng(&mut rand::rng(), msg)?;
         Ok(signature.into())
     }
 }
 
-struct RustPkiProvider<'a> {
-    rng: rand::rngs::OsRng,
+struct RustPkiProvider<'a, RNG> {
+    rng: RNG,
     verifier: CertVerifier<'a, Aes128GcmSha256, SystemTime, 4096>,
     priv_key: Option<&'a [u8]>,
     client_cert: Option<embedded_tls::Certificate<&'a [u8]>>,
 }
 
-impl CryptoProvider for RustPkiProvider<'_> {
+impl<RNG: CryptoRng> CryptoProvider for RustPkiProvider<'_, RNG> {
     type CipherSuite = Aes128GcmSha256;
     type Signature = Box<[u8]>;
 
-    fn rng(&mut self) -> impl embedded_tls::CryptoRngCore {
+    fn rng(&mut self) -> impl CryptoRng {
         &mut self.rng
     }
 
@@ -57,7 +53,6 @@ impl CryptoProvider for RustPkiProvider<'_> {
         let private_key =
             rsa::RsaPrivateKey::from_pkcs8_der(key_der).map_err(|_| TlsError::InvalidPrivateKey)?;
         let signer = RsaPssSigningKey {
-            rng: &mut self.rng,
             key: rsa::pss::SigningKey::<Sha256>::new(private_key),
         };
 
@@ -89,8 +84,6 @@ fn setup() -> SocketAddr {
         std::thread::spawn(move || {
             use tlsserver::*;
 
-            let versions = &[&rustls::version::TLS13];
-
             let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
 
             let ca = load_certs(&test_dir.join("data").join("rsa-ca-cert.pem"));
@@ -98,19 +91,17 @@ fn setup() -> SocketAddr {
             let privkey = load_private_key(&test_dir.join("data").join("rsa-server-key.pem"));
 
             let mut client_auth_roots = rustls::RootCertStore::empty();
-            for root in ca.iter() {
+            for root in ca.into_iter() {
                 client_auth_roots.add(root).unwrap()
             }
 
-            let client_cert_verifier =
-                AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots);
+            let client_cert_verifier = WebPkiClientVerifier::builder(Arc::new(client_auth_roots))
+                .allow_unauthenticated()
+                .build()
+                .unwrap();
 
             let config = rustls::ServerConfig::builder()
-                .with_cipher_suites(rustls::ALL_CIPHER_SUITES)
-                .with_kx_groups(&rustls::ALL_KX_GROUPS)
-                .with_protocol_versions(versions)
-                .unwrap()
-                .with_client_cert_verifier(client_cert_verifier.boxed())
+                .with_client_cert_verifier(client_cert_verifier)
                 .with_single_cert(certs, privkey)
                 .unwrap();
 
@@ -156,7 +147,7 @@ async fn test_server_certificate_validation() {
     let open_fut = tls.open(TlsContext::new(
         &config,
         RustPkiProvider {
-            rng: OsRng,
+            rng: rand::rng(),
             verifier: CertVerifier::new(Certificate::X509(&der[..])),
             priv_key: Some(&key_der),
             client_cert: Some(Certificate::X509(&cli_der[..])),

--- a/tests/rustpki_test.rs
+++ b/tests/rustpki_test.rs
@@ -5,11 +5,10 @@ use embedded_tls::pki::CertVerifier;
 use embedded_tls::{Aes128GcmSha256, CryptoProvider, SignatureScheme, TlsError, TlsVerifier};
 use p256::SecretKey;
 use p256::ecdsa::{DerSignature, SigningKey};
-use rand_core::OsRng;
-use rustls::server::AllowAnyAnonymousOrAuthenticatedClient;
-use signature::SignerMut;
+use rand_core::CryptoRng;
+use rustls::server::WebPkiClientVerifier;
 use std::net::SocketAddr;
-use std::sync::Once;
+use std::sync::{Arc, Once};
 use std::time::SystemTime;
 
 mod tlsserver;
@@ -18,18 +17,18 @@ static LOG_INIT: Once = Once::new();
 static INIT: Once = Once::new();
 static mut ADDR: Option<SocketAddr> = None;
 
-struct RustPkiProvider<'a> {
-    rng: rand::rngs::OsRng,
+struct RustPkiProvider<'a, RNG> {
+    rng: RNG,
     verifier: CertVerifier<'a, Aes128GcmSha256, SystemTime, 4096>,
     priv_key: Option<&'a [u8]>,
     client_cert: Option<embedded_tls::Certificate<&'a [u8]>>,
 }
 
-impl CryptoProvider for RustPkiProvider<'_> {
+impl<RNG: CryptoRng> CryptoProvider for RustPkiProvider<'_, RNG> {
     type CipherSuite = Aes128GcmSha256;
     type Signature = DerSignature;
 
-    fn rng(&mut self) -> impl embedded_tls::CryptoRngCore {
+    fn rng(&mut self) -> impl CryptoRng {
         &mut self.rng
     }
 
@@ -73,8 +72,6 @@ fn setup() -> SocketAddr {
         std::thread::spawn(move || {
             use tlsserver::*;
 
-            let versions = &[&rustls::version::TLS13];
-
             let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
 
             let ca = load_certs(&test_dir.join("data").join("ca-cert.pem"));
@@ -82,19 +79,17 @@ fn setup() -> SocketAddr {
             let privkey = load_private_key(&test_dir.join("data").join("im-server-key.pem"));
 
             let mut client_auth_roots = rustls::RootCertStore::empty();
-            for root in ca.iter() {
+            for root in ca.into_iter() {
                 client_auth_roots.add(root).unwrap()
             }
 
-            let client_cert_verifier =
-                AllowAnyAnonymousOrAuthenticatedClient::new(client_auth_roots);
+            let client_cert_verifier = WebPkiClientVerifier::builder(Arc::new(client_auth_roots))
+                .allow_unauthenticated()
+                .build()
+                .unwrap();
 
             let config = rustls::ServerConfig::builder()
-                .with_cipher_suites(rustls::ALL_CIPHER_SUITES)
-                .with_kx_groups(&rustls::ALL_KX_GROUPS)
-                .with_protocol_versions(versions)
-                .unwrap()
-                .with_client_cert_verifier(client_cert_verifier.boxed())
+                .with_client_cert_verifier(client_cert_verifier)
                 .with_single_cert(certs, privkey)
                 .unwrap();
 
@@ -134,7 +129,7 @@ async fn test_server_certificate_validation() {
     let open_fut = tls.open(TlsContext::new(
         &config,
         RustPkiProvider {
-            rng: OsRng,
+            rng: rand::rng(),
             verifier: CertVerifier::new(Certificate::X509(&der[..])),
             priv_key: None,
             client_cert: None,
@@ -181,7 +176,7 @@ async fn test_mutual_certificate_validation() {
     let open_fut = tls.open(TlsContext::new(
         &config,
         RustPkiProvider {
-            rng: OsRng,
+            rng: rand::rng(),
             verifier: CertVerifier::new(Certificate::X509(&ca_der[..])),
             priv_key: Some(&key_der),
             client_cert: Some(Certificate::X509(&cli_der[..])),

--- a/tests/split_test.rs
+++ b/tests/split_test.rs
@@ -1,18 +1,19 @@
 #![macro_use]
+
+use std::net::{SocketAddr, TcpStream};
+use std::sync::OnceLock;
+
 use embedded_io::{Read, Write};
 use embedded_io_adapters::std::FromStd;
-use rand_core::OsRng;
-use std::net::{SocketAddr, TcpStream};
-use std::sync::Once;
 
 mod tlsserver;
 
-static INIT: Once = Once::new();
-static mut ADDR: Option<SocketAddr> = None;
+static ADDR: OnceLock<SocketAddr> = OnceLock::new();
 
 fn setup() -> SocketAddr {
     use mio::net::TcpListener;
-    INIT.call_once(|| {
+
+    *ADDR.get_or_init(|| {
         env_logger::init();
 
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
@@ -25,12 +26,9 @@ fn setup() -> SocketAddr {
         std::thread::spawn(move || {
             tlsserver::run(listener);
         });
-        #[allow(static_mut_refs)]
-        unsafe {
-            ADDR.replace(addr)
-        };
-    });
-    unsafe { ADDR.unwrap() }
+
+        addr
+    })
 }
 
 pub struct Clonable<T: ?Sized>(std::sync::Arc<T>);
@@ -84,7 +82,7 @@ fn test_blocking_borrowed() {
 
     tls.open(TlsContext::new(
         &config,
-        UnsecureProvider::new::<Aes128GcmSha256>(OsRng),
+        UnsecureProvider::new::<Aes128GcmSha256>(rand::rng()),
     ))
     .expect("error establishing TLS connection");
 

--- a/tests/tlsserver.rs
+++ b/tests/tlsserver.rs
@@ -1,12 +1,11 @@
-use std::{path::PathBuf, sync::Arc};
-
-use mio::net::{TcpListener, TcpStream};
-
 use std::collections::HashMap;
 use std::fs;
 use std::io;
 use std::io::{BufReader, Read, Write};
 use std::net;
+use std::{path::PathBuf, sync::Arc};
+
+use mio::net::{TcpListener, TcpStream};
 
 // Token for our listening socket.
 pub const LISTENER: mio::Token = mio::Token(0);
@@ -324,25 +323,29 @@ impl Connection {
     }
 }
 
-pub fn load_certs(filename: &PathBuf) -> Vec<rustls::Certificate> {
+pub fn load_certs(filename: &PathBuf) -> Vec<rustls::pki_types::CertificateDer<'static>> {
     let certfile = fs::File::open(filename).expect("cannot open certificate file");
     let mut reader = BufReader::new(certfile);
     rustls_pemfile::certs(&mut reader)
-        .unwrap()
-        .iter()
-        .map(|v| rustls::Certificate(v.clone()))
+        .map(|v| v.unwrap())
         .collect()
 }
 
-pub fn load_private_key(filename: &PathBuf) -> rustls::PrivateKey {
+pub fn load_private_key(filename: &PathBuf) -> rustls::pki_types::PrivateKeyDer<'static> {
     let keyfile = fs::File::open(filename).expect("cannot open private key file");
     let mut reader = BufReader::new(keyfile);
 
     loop {
         match rustls_pemfile::read_one(&mut reader).expect("cannot parse private key .pem file") {
-            Some(rustls_pemfile::Item::RSAKey(key)) => return rustls::PrivateKey(key),
-            Some(rustls_pemfile::Item::PKCS8Key(key)) => return rustls::PrivateKey(key),
-            Some(rustls_pemfile::Item::ECKey(key)) => return rustls::PrivateKey(key),
+            Some(rustls_pemfile::Item::Pkcs1Key(key)) => {
+                return rustls::pki_types::PrivateKeyDer::Pkcs1(key);
+            }
+            Some(rustls_pemfile::Item::Pkcs8Key(key)) => {
+                return rustls::pki_types::PrivateKeyDer::Pkcs8(key);
+            }
+            Some(rustls_pemfile::Item::Sec1Key(key)) => {
+                return rustls::pki_types::PrivateKeyDer::Sec1(key);
+            }
             None => break,
             _ => {}
         }
@@ -356,18 +359,12 @@ pub fn load_private_key(filename: &PathBuf) -> rustls::PrivateKey {
 
 #[allow(dead_code)]
 pub fn run(listener: TcpListener) {
-    let versions = &[&rustls::version::TLS13];
-
     let test_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
 
     let certs = load_certs(&test_dir.join("data").join("server-cert.pem"));
     let privkey = load_private_key(&test_dir.join("data").join("server-key.pem"));
 
     let config = rustls::ServerConfig::builder()
-        .with_cipher_suites(rustls::ALL_CIPHER_SUITES)
-        .with_kx_groups(&rustls::ALL_KX_GROUPS)
-        .with_protocol_versions(versions)
-        .unwrap()
         .with_no_client_auth()
         .with_single_cert(certs, privkey)
         .unwrap();

--- a/tests/webpki_test.rs
+++ b/tests/webpki_test.rs
@@ -1,26 +1,28 @@
 #![cfg(feature = "webpki")]
 
-use embedded_io_adapters::tokio_1::FromTokio;
-use embedded_tls::webpki::CertVerifier;
-use embedded_tls::{Aes128GcmSha256, CryptoProvider, TlsVerifier};
 use std::net::SocketAddr;
 use std::sync::OnceLock;
 use std::time::SystemTime;
+
+use embedded_io_adapters::tokio_1::FromTokio;
+use embedded_tls::webpki::CertVerifier;
+use embedded_tls::{Aes128GcmSha256, CryptoProvider, TlsVerifier};
+use rand_core::CryptoRng;
 
 mod tlsserver;
 
 static LOG_INIT: OnceLock<()> = OnceLock::new();
 
-struct WebPkiProvider<'a> {
-    rng: rand::rngs::OsRng,
+struct WebPkiProvider<'a, RNG> {
+    rng: RNG,
     verifier: CertVerifier<'a, Aes128GcmSha256, SystemTime, 4096>,
 }
 
-impl CryptoProvider for WebPkiProvider<'_> {
+impl<RNG: CryptoRng> CryptoProvider for WebPkiProvider<'_, RNG> {
     type CipherSuite = Aes128GcmSha256;
     type Signature = &'static [u8];
 
-    fn rng(&mut self) -> impl embedded_tls::CryptoRngCore {
+    fn rng(&mut self) -> impl CryptoRng {
         &mut self.rng
     }
 
@@ -85,7 +87,7 @@ async fn test_server_certificate_validation() {
     let open_fut = tls.open(TlsContext::new(
         &config,
         WebPkiProvider {
-            rng: rand::rngs::OsRng,
+            rng: rand::rng(),
             verifier: CertVerifier::new(Certificate::X509(&der[..])),
         },
     ));


### PR DESCRIPTION
Third time's the charm after #164 and #178: Finally, many RustCrypto dependencies have gotten new final versions, with only `rsa` left at an RC version.

This change sets the `rust-version` property in `Cargo.toml` for the first time. 1.87 is the minimum here due to the `heapless` 0.9.x dependency.

This PR also replaces the fix from #192 by the fix I already came up with in #178. Unlike #192, it's shorter and reuses the existing `LabelBufferSize` without introducing a magic number 70.

Let's hope that an `rsa` 0.10.0 final is released soon, so that this PR doesn't bitrot for months again :)

Depends on https://github.com/RustCrypto/RSA/issues/647
Supersedes #178

CC @bugadani @lulf @newAM