### PR TITLE
chore: bump der to 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ embedded-io-adapters = { version = "0.7", optional = true }
 generic-array = { version = "0.14", default-features = false }
 webpki = { package = "rustls-webpki", version = "0.101.7", default-features = false, optional = true }
 const-oid = { version = "0.10.1", optional = true }
-der = { version = "0.8.0-rc.2", features = ["derive", "oid", "heapless"], optional = true }
+der = { version = "0.8.1", features = ["derive", "oid", "heapless"], optional = true }
 signature = { version = "2.2", default-features = false }
 ecdsa = { version = "0.16.9", default-features = false }
 


### PR DESCRIPTION
Bumps `der` to a 0.8.1, a version that isn't a release candidate.

Ran clippy 

```sh
cargo clippy && cargo clippy --no-default-features --features "p384,rsa,ed25519,defmt,rustpki"
```

And tested using the Ariel OS http example on esp32c6 and raspberry pico 2.