### PR TITLE
Add check_can_recv to check for socket readiness

### DIFF
--- a/src/asynch.rs
+++ b/src/asynch.rs
@@ -217,6 +217,20 @@ where
         } else {
             Err(TlsError::MissingHandshake)
         }
+    }    
+    
+    /// Get whether the socket is ready to receive data, i.e. whether there is some pending data in the receive buffer.
+    /// This function needs to decrypt the provided data first
+    pub async fn check_can_recv(&mut self) -> Result<bool, TlsError> {
+        if self.is_opened() {
+            if self.decrypted.is_empty() {
+                self.read_application_data().await?;
+            }
+
+            Ok(!self.decrypted.is_empty())
+        } else {
+            Err(TlsError::MissingHandshake)
+        }
     }
 
     async fn read_application_data(&mut self) -> Result<(), TlsError> {


### PR DESCRIPTION
The Problem is, that there is no way to check weather `TlsConnection::read` will **block** (e.g. if no more data is recieved yet).
The "_underlaying_" `embassy_net::tcp::TcpSocket`, for example, solves this problem by providing a `can_recv()` function.

to this Problem, I propose a `check_can_recv` method to check if socket `read()` would block to wait for new incoming data, or if it can return data, without having to wait for new data from the server.