### PR TITLE
Fix record-stream desync when an async read is cancelled and resumed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix a record-stream desync when an async record read is cancelled and resumed (e.g. under a read/write `select`): persist the partial record header on the reader, and read only the still-missing body bytes in `advance` instead of a fixed `amount`.
+
 ## 0.19.0 - 2026-06-01
 
 - Added post-quantum hybrid named groups.

--- a/src/record_reader.rs
+++ b/src/record_reader.rs
@@ -14,6 +14,11 @@ pub struct RecordReader<'a> {
     decoded: usize,
     /// The number of read but not yet decoded bytes in the buffer
     pending: usize,
+    /// Partial record header bytes read so far. Persisted here (not on the
+    /// read future's stack) so a cancelled async read resumes the header
+    /// instead of dropping consumed bytes and desyncing the record stream.
+    header_buf: [u8; RecordHeader::LEN],
+    header_read: usize,
 }
 
 pub struct RecordReaderBorrowMut<'a> {
@@ -22,6 +27,8 @@ pub struct RecordReaderBorrowMut<'a> {
     decoded: &'a mut usize,
     /// The number of read but not yet decoded bytes in the buffer
     pending: &'a mut usize,
+    header_buf: &'a mut [u8; RecordHeader::LEN],
+    header_read: &'a mut usize,
 }
 
 impl<'a> RecordReader<'a> {
@@ -33,6 +40,8 @@ impl<'a> RecordReader<'a> {
             buf,
             decoded: 0,
             pending: 0,
+            header_buf: [0; RecordHeader::LEN],
+            header_read: 0,
         }
     }
 
@@ -41,6 +50,8 @@ impl<'a> RecordReader<'a> {
             buf: self.buf,
             decoded: &mut self.decoded,
             pending: &mut self.pending,
+            header_buf: &mut self.header_buf,
+            header_read: &mut self.header_read,
         }
     }
 
@@ -53,6 +64,8 @@ impl<'a> RecordReader<'a> {
             self.buf,
             &mut self.decoded,
             &mut self.pending,
+            &mut self.header_buf,
+            &mut self.header_read,
             transport,
             key_schedule,
         )
@@ -84,6 +97,8 @@ impl RecordReaderBorrowMut<'_> {
             self.buf,
             self.decoded,
             self.pending,
+            self.header_buf,
+            self.header_read,
             transport,
             key_schedule,
         )
@@ -109,19 +124,40 @@ pub async fn read<'m, CipherSuite: TlsCipherSuite>(
     buf: &'m mut [u8],
     decoded: &mut usize,
     pending: &mut usize,
+    header_buf: &mut [u8; RecordHeader::LEN],
+    header_read: &mut usize,
     transport: &mut impl AsyncRead,
     key_schedule: &mut ReadKeySchedule<CipherSuite>,
 ) -> Result<ServerRecord<'m, CipherSuite>, TlsError> {
-    let header: RecordHeader = next_record_header(transport).await?;
+    // Resumable header read: `header_buf`/`header_read` live in the caller's
+    // RecordReader, so if this future is dropped (e.g. a concurrent TX wins a
+    // `select`) mid-header, the bytes already pulled from the transport are
+    // kept and the next call continues instead of restarting mid-record.
+    while *header_read < RecordHeader::LEN {
+        let read = transport
+            .read(&mut header_buf[*header_read..])
+            .await
+            .map_err(|e| TlsError::Io(e.kind()))?;
+        if read == 0 {
+            return Err(TlsError::IoError);
+        }
+        *header_read += read;
+    }
+    let header = RecordHeader::decode(*header_buf)?;
 
+    // `advance` is already resumable via `pending`; if it is cancelled,
+    // `header_read` stays full so the header is re-decoded on resume.
     advance(buf, decoded, pending, transport, header.content_length()).await?;
-    consume(
+    let result = consume(
         buf,
         decoded,
         pending,
         header,
         key_schedule.transcript_hash(),
-    )
+    );
+    // Whole record (header + body) is in the buffer now; arm for the next one.
+    *header_read = 0;
+    result
 }
 
 pub fn read_blocking<'m, CipherSuite: TlsCipherSuite>(
@@ -141,22 +177,6 @@ pub fn read_blocking<'m, CipherSuite: TlsCipherSuite>(
         header,
         key_schedule.transcript_hash(),
     )
-}
-
-async fn next_record_header(transport: &mut impl AsyncRead) -> Result<RecordHeader, TlsError> {
-    let mut buf: [u8; RecordHeader::LEN] = [0; RecordHeader::LEN];
-    let mut total_read: usize = 0;
-    while total_read != RecordHeader::LEN {
-        let read: usize = transport
-            .read(&mut buf[total_read..])
-            .await
-            .map_err(|e| TlsError::Io(e.kind()))?;
-        if read == 0 {
-            return Err(TlsError::IoError);
-        }
-        total_read += read;
-    }
-    RecordHeader::decode(buf)
 }
 
 fn next_record_header_blocking(
@@ -185,16 +205,19 @@ async fn advance(
 ) -> Result<(), TlsError> {
     ensure_contiguous(buf, decoded, pending, amount)?;
 
-    let mut remain: usize = amount;
+    // Read only the bytes still missing for this record. On a resumed call
+    // `*pending` already holds part of the record, so capping the read at
+    // `amount - *pending` (rather than a fixed `amount`) avoids over-reading
+    // into the next record and stranding those bytes — which desynced the
+    // record stream on the next header read.
     while *pending < amount {
         let read = transport
-            .read(&mut buf[*decoded + *pending..][..remain])
+            .read(&mut buf[*decoded + *pending..][..amount - *pending])
             .await
             .map_err(|e| TlsError::Io(e.kind()))?;
         if read == 0 {
             return Err(TlsError::IoError);
         }
-        remain -= read;
         *pending += read;
     }
 
@@ -210,15 +233,13 @@ fn advance_blocking(
 ) -> Result<(), TlsError> {
     ensure_contiguous(buf, decoded, pending, amount)?;
 
-    let mut remain: usize = amount;
     while *pending < amount {
         let read = transport
-            .read(&mut buf[*decoded + *pending..][..remain])
+            .read(&mut buf[*decoded + *pending..][..amount - *pending])
             .map_err(|e| TlsError::Io(e.kind()))?;
         if read == 0 {
             return Err(TlsError::IoError);
         }
-        remain -= read;
         *pending += read;
     }
 
@@ -474,6 +495,47 @@ mod tests {
 
             assert_eq!(0, reader.decoded);
             assert_eq!(0, reader.pending);
+        }
+    }
+
+    // Regression: a resumed body read (entered with `pending` already holding
+    // part of the record, e.g. after the read future was cancelled by a
+    // `select` and polled again) must read only `amount - pending` more bytes.
+    // Reading a fixed `amount` over-reads into the next record and desyncs the
+    // stream. `advance` and `advance_blocking` share this logic.
+    fn advance_resume_case(chunk_size: usize) {
+        // 8 bytes available; the record wants 5 and already has 2 pending, so
+        // exactly 3 more should be consumed — leaving 5 for the next record.
+        let mut transport = ChunkRead(
+            &[0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88],
+            chunk_size,
+        );
+
+        let mut buf = [0u8; 32];
+        buf[0] = 0xaa; // 2 bytes of this record already buffered
+        buf[1] = 0xbb;
+        let mut decoded = 0usize;
+        let mut pending = 2usize;
+
+        advance_blocking(&mut buf, &mut decoded, &mut pending, &mut transport, 5).unwrap();
+
+        assert_eq!(
+            5, pending,
+            "chunk_size={chunk_size}: record should be full, not over-read"
+        );
+        assert_eq!(0, decoded);
+        assert_eq!(
+            5,
+            transport.0.len(),
+            "chunk_size={chunk_size}: over-read into the next record"
+        );
+        assert_eq!(&[0xaa, 0xbb, 0x11, 0x22, 0x33], &buf[..5]);
+    }
+
+    #[test]
+    fn advance_only_reads_missing_bytes_on_resume() {
+        for chunk_size in 1..=8 {
+            advance_resume_case(chunk_size);
         }
     }
 }


### PR DESCRIPTION
## Problem

`RecordReader`'s async `read` is not cancellation-safe. When it is polled inside a `select` that also drives a writer — a common pattern for a full-duplex protocol over a single socket, e.g. MQTT — a ready write can drop the in-progress read future. On the next poll the read has to resume exactly where it left off, but two places don't:

1. `next_record_header` reads the 5-byte header into a buffer on the read future's stack. If the future is dropped mid-header, those bytes are lost and the next read starts in the middle of a record.
2. `advance` reads a fixed `amount` even when `*pending` bytes of the record are already buffered (which is exactly the case on a resumed read). It over-reads by `*pending`, pulling bytes that belong to the next record and stranding them, so the following header is decoded from the wrong offset.

Either way the record framing desyncs and the next `RecordHeader::decode` returns `InvalidRecord`, tearing the connection down.

## Fix

1. Persist the partial header on `RecordReader` (`header_buf` / `header_read`) so a cancelled header read resumes instead of restarting mid-record.
2. In `advance` / `advance_blocking`, read only the bytes still missing (`amount - *pending`). This also removes a latent slice out-of-bounds when `*pending > 0`.

Both are needed: the header fix enables a clean resume, and the `advance` fix keeps that resume from over-reading.

## Test

Adds `advance_only_reads_missing_bytes_on_resume`, which drives `advance_blocking` with a pre-set `pending` across chunk sizes and asserts it consumes exactly the missing bytes and does not reach into the next record. It fails on the old code and passes with the fix.

## How it was found

Against a real workload — a firmware TLS/MQTT client doing OTA firmware downloads over a lossy cellular link. The reader runs under a `select(read, write)`, and each reconnect replays large records, which makes the cancel/resume path frequent. Before this change: `InvalidRecord` after a couple of reconnects. After: 13 forced reconnects with zero desyncs.
